### PR TITLE
Support for unphased genotypes.

### DIFF
--- a/genomatnn/plots.py
+++ b/genomatnn/plots.py
@@ -666,7 +666,7 @@ def hap_matrix1(
     indicating the population of origin for a given haplotype/genotype column.
     """
     # vmax heuristic to make the patterns clear
-    x = ploidy if phased else 1
+    x = 1 if phased else ploidy
     vmax = int(round(x * np.log2(sequence_length / 20 / A.shape[0])))
     im = ax.imshow(
         A,
@@ -730,7 +730,7 @@ def hap_matrix1(
     if phased:
         ax_pops.set_xlabel("Haplotypes")
     else:
-        ax_pops.set_xlabel("Genotypes")
+        ax_pops.set_xlabel("Individuals")
 
     ax.figure.tight_layout()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -31,14 +31,16 @@ def capture(func, *args, **kwargs):
 class ConfigMixin:
     need_sim_data = False
     need_trained_model = False
+    phased = False
 
     @classmethod
     def setUpClass(cls):
         cls.temp_dir = tempfile.TemporaryDirectory()
         cls.config_file = pathlib.Path(cls.temp_dir.name) / "config.toml"
-        # load the example toml, patch in temp_dir, and write it back out
+        # load the example toml, patch it, then write it back out
         d = toml.load("examples/test-example.toml")
         d["dir"] = cls.temp_dir.name
+        d["vcf"]["phased"] = cls.phased
         with open(cls.config_file, "w") as f:
             toml.dump(d, f)
         cls.conf = config.Config(cls.config_file)
@@ -158,6 +160,10 @@ class TestEval(ConfigMixin, unittest.TestCase):
             self.assertTrue((plot_dir / plot_file).exists())
 
 
+class TestEval_phased(TestEval):
+    phased = True
+
+
 class TestApply(ConfigMixin, unittest.TestCase):
     need_sim_data = True
     need_trained_model = True
@@ -178,6 +184,10 @@ class TestApply(ConfigMixin, unittest.TestCase):
             "predictions.pdf",
         ]:
             self.assertTrue((plot_dir / pred_file).exists())
+
+
+class TestApply_phased(TestApply):
+    phased = True
 
 
 class TestVcfplot(ConfigMixin, unittest.TestCase):

--- a/tests/test_tfstuff.py
+++ b/tests/test_tfstuff.py
@@ -28,9 +28,11 @@ class TestModelConstruction(unittest.TestCase):
                 pop_indices=pop_indices,
                 ref_pop=0,
                 num_rows=num_rows,
-                num_cols=num_inds,
+                num_haplotypes=num_inds,
                 maf_thres=maf_thres,
                 rng=rng,
+                phased=True,
+                ploidy=2,
             )
         self.assertEqual(A.shape, (num_rows, num_inds))
         self.A = A[np.newaxis, :, :, np.newaxis]


### PR DESCRIPTION
All genotypes are treated as either phased, or unphased. Mixed phasing
is not supported in any clever way---just use the unphased option.
For unphased data, we still encode the density of minor alleles, but the
density is added across the two unphased columns of a diploid individual.
For an unresized matrix, this encodes the number of minor alleles (0, 1, or 2)
observed at a given site.
Collapsing unphased data is done before haplotype/genotype sorting.